### PR TITLE
Manage PHP apache config file  as empty to protect apache updates

### DIFF
--- a/modules/install/manifests/web.pp
+++ b/modules/install/manifests/web.pp
@@ -259,7 +259,8 @@ class install::web (
         '/00-systemd.conf',
         '/01-cgi.conf',
         '/10-h2.conf',
-        '/10-proxy_h2.conf'], $::apache::mod_dir):
+        '/10-proxy_h2.conf',
+        '/15-php.conf'], $::apache::mod_dir):
         ensure  => file,
         content => $new_file_content,
         notify => Class['apache::service'],


### PR DESCRIPTION
refs #24 

php package install also a config file /etc/httpd/conf.modules.d/15-php.conf, so we have to manage it as empty file. 